### PR TITLE
Fix a casing issue in FBD6

### DIFF
--- a/src/main/java/com/wavefront/integrations/FDBLogListener.java
+++ b/src/main/java/com/wavefront/integrations/FDBLogListener.java
@@ -172,7 +172,7 @@ public class FDBLogListener extends TailerListenerAdapter {
                         case "StorageMetrics": {
                             String port = getPort(map);
                             addDoubleGauges(map, port, Arrays.asList("Fetch"));
-                            addDoubleGauges(map, port, Arrays.asList("bytes", "StorageVersion",
+                            addDoubleGauges(map, port, Arrays.asList("bytes", "Bytes", "StorageVersion",
                                     "DurableVersion", "LoopsPerSecond", "MutationBytesPerSecond",
                                     "QueriesPerSecond", "Query", "Version", "IdleTime",
                                     "ChangesPerSecond", "ElapsedTime", "BytesFetchedPerSecond"));


### PR DESCRIPTION
In FDB6, some metrics that used to fall under "bytes" are now reported as "Bytes".  This change simply adds compatibility for both.