### PR TITLE
Enable multiple endpoints feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,14 @@ The command line argument options are as follows:
      --type is set to DIRECT.
      
 --token
-     The API token for Wavefront direct ingestion.  Used only if --type is set to
+     The API token for Wavefront direct ingestion. Used only if --type is set to
      DIRECT.
+
+--endPoints
+    A list of Wavefront endpoints to send metrics. Used only if --type is set to DIRECT.
+
+--serviceName
+    Optional variable to control the name of the service reported. Defaults to fdbtailer.
      
 --type
      The type of reporter that should be used to report the metrics gathered.
@@ -87,6 +93,8 @@ proxyPort:
 reporterType:
 server:
 token:
+endPoints:
+serviceName
 ```
 
 An example YAML configuration file is included as example_config.yaml in this repo, and is reproduced here:
@@ -145,12 +153,14 @@ If you are running a Graphite server, a Graphite reporter can also be used by sp
     --matching ".*"
 ```
 
-### Using the Sharded Reporter
+### Using multiple Wavefront endpoints
 
-If you are running FDB with a sharded memory tier, a special reporter can also be used to apply an additional point tag to all metrics indicating which shard the point is coming from.  The new point tag's key is `cluster_file` and the value is whichever cluster file that shard is using (read from the top of each log). Currently this reporter requires a Wavefront proxy, but if there is interest in extending that please file a github issue.
+In order to send metrics to multiple Wavefront endpoint, you will need to provide a list of endpoints and the [Wavefront API](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token) token. Here is an example of the options to provide in a YAML configuration file. Note that the reporter type must be `DIRECT`. 
 ```
-    --type SHARDED
-    --proxyHost 127.0.0.1
-    --dir "/usr/local/foundationdb/logs"
-    --matching ".*\\.xml$"
+    directory: "/usr/local/foundationdb/logs"
+    matching: ".*\\.xml$"
+    reporterType: DIRECT
+    endPoints:
+        - endPoint1: token@endPoint1.wavefront.com
+        - endPoint2: token@endPoint2.wavefront.com
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-sdk-java</artifactId>
-            <version>0.9.0</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>com.wavefront</groupId>
@@ -82,11 +82,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.wavefront</groupId>
-            <artifactId>wavefront-internal-reporter-java</artifactId>
-            <version>1.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/wavefront/integrations/FDBLogListener.java
+++ b/src/main/java/com/wavefront/integrations/FDBLogListener.java
@@ -69,13 +69,13 @@ public class FDBLogListener extends TailerListenerAdapter {
     }
 
     public FDBLogListener(String prefix, LoadingCache<String, AtomicDouble> values,
-                          LoadingCache<String, Gauge<Double>> gauges, WavefrontSender wavefrontSender) {
+                          LoadingCache<String, Gauge<Double>> gauges, WavefrontSender wavefrontSender, String serviceName) {
         this.prefix = prefix;
         this.values = values;
         this.gauges = gauges;
         this.wavefrontSender = wavefrontSender;
         this.failed = SharedMetricRegistries.getDefault().counter(addPrefix("listener_failed"));
-        this.tags = new HashMap<String, String>();
+        this.tags = new HashMap<String, String>() {{put("service", serviceName);}};
     }
 
     @Override

--- a/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
+++ b/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
@@ -34,11 +34,11 @@ public class FDBMetricsReporter {
 
     private final static int METRICS_REPORTING_PERIOD = 60;
 
-    private final static int BATCH_SIZE = 20_000;
+    private final static int BATCH_SIZE = 50_000;
 
     private final static int MAX_QUEUE_SIZE = 100_000;
 
-    private final static int FLUSH_INTERVAL_SECONDS = 2;
+    private final static int FLUSH_INTERVAL_SECONDS = 60;
 
     static {
         SharedMetricRegistries.setDefault("defaultFDBMetrics", new MetricRegistry());

--- a/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
+++ b/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
@@ -234,7 +234,7 @@ public class FDBMetricsReporter {
                     return;
                 }
 
-                Tailer tailer = new Tailer(logFile, new FDBLogListener(prefix, values, gauges, wavefrontSender), 1000, true);
+                Tailer tailer = new Tailer(logFile, new FDBLogListener(prefix, values, gauges, wavefrontSender, SERVICE_NAME), 1000, true);
                 es.submit(tailer);
                 if (files.putIfAbsent(logFile, tailer) != null) {
                     // The put didn't succeed, stop the tailer.

--- a/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
+++ b/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
@@ -8,16 +8,16 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.wavefront.dropwizard.metrics.DropwizardMetricsReporter;
-import com.wavefront.internal.reporter.WavefrontInternalReporter;
 import com.wavefront.sdk.common.WavefrontSender;
-import com.wavefront.sdk.direct_ingestion.WavefrontDirectIngestionClient;
-import com.wavefront.sdk.proxy.WavefrontProxyClient;
+import com.wavefront.sdk.common.clients.WavefrontClientFactory;
 import org.apache.commons.io.input.Tailer;
 
 import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,11 +30,15 @@ public class FDBMetricsReporter {
 
     private final static Logger logger = Logger.getLogger(FDBMetricsReporter.class.getCanonicalName());
 
-    private final static String SERVICE_NAME = "fdbtailer";
-
     private final static int FILE_PARSING_PERIOD = 30;
 
     private final static int METRICS_REPORTING_PERIOD = 60;
+
+    private final static int BATCH_SIZE = 20_000;
+
+    private final static int MAX_QUEUE_SIZE = 100_000;
+
+    private final static int FLUSH_INTERVAL_SECONDS = 2;
 
     static {
         SharedMetricRegistries.setDefault("defaultFDBMetrics", new MetricRegistry());
@@ -42,9 +46,7 @@ public class FDBMetricsReporter {
 
     private ScheduledReporter reporter;
 
-    private WavefrontInternalReporter shardedReporter = null;
-
-    private WavefrontSender sender;
+    private WavefrontSender wavefrontSender;
 
     private String directory;
 
@@ -55,6 +57,8 @@ public class FDBMetricsReporter {
     private LoadingCache<String, AtomicDouble> values;
 
     private LoadingCache<String, Gauge<Double>> gauges;
+
+    private String SERVICE_NAME = "fdbtailer";
 
     String metricName(String name) {
         return prefix + name;
@@ -90,36 +94,51 @@ public class FDBMetricsReporter {
                 }
         );
 
+        if (arguments.getServiceName() != null) {
+            SERVICE_NAME = arguments.getServiceName();
+        }
+
         if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.PROXY) {
             initProxy(arguments.getProxyHost(), arguments.getProxyPort());
         } else if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.DIRECT) {
-            initDirect(arguments.getServer(), arguments.getToken());
+            initDirect(arguments.getServer(), arguments.getToken(), arguments.getEndPoints());
         } else if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.GRAPHITE) {
             initGraphite(arguments.getGraphiteServer(), arguments.getGraphitePort());
-        } else if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.SHARDED) {
-            initSharded(arguments.getProxyHost(), arguments.getProxyPort());
         }
     }
 
-    private void initDirect(String server, String token) {
-        this.sender = new WavefrontDirectIngestionClient.Builder(server, token).build();
+    private void initDirect(String server, String token, List<Map<String, String>> endPoints) {
+        WavefrontClientFactory wavefrontClientFactory = new WavefrontClientFactory();
+
+        if (endPoints != null) {
+            for (Map<String, String> endPointMap : endPoints) {
+                for (Map.Entry<String, String> entry : endPointMap.entrySet()) {
+                    String endPoint = "https://" + entry.getValue();
+                    this.wavefrontSender = addWavefrontClient(wavefrontClientFactory, endPoint);
+                }
+            }
+        } else {
+            String endPoint = "https://" + token + "@" + server;
+            this.wavefrontSender = addWavefrontClient(wavefrontClientFactory, endPoint);
+        }
 
         this.reporter = DropwizardMetricsReporter.forRegistry(SharedMetricRegistries.getDefault()).
                 withSource(getHostName()).
                 withReporterPointTag("service", SERVICE_NAME).
                 withJvmMetrics().
-                build(this.sender);
+                build(this.wavefrontSender);
     }
 
     private void initProxy(String proxyHostname, int proxyPort) throws UnknownHostException {
-        this.sender = new WavefrontProxyClient.Builder(proxyHostname).metricsPort(proxyPort).build();
+        String proxyURL = "proxy://" + proxyHostname + ":" + proxyPort;
+        WavefrontClientFactory wavefrontClientFactory = new WavefrontClientFactory();
+        this.wavefrontSender = addWavefrontClient(wavefrontClientFactory, proxyURL);
 
         this.reporter = DropwizardMetricsReporter.forRegistry(SharedMetricRegistries.getDefault()).
                 withSource(getHostName()).
                 withReporterPointTag("service", SERVICE_NAME).
                 withJvmMetrics().
-                build(this.sender);
-
+                build(this.wavefrontSender);
     }
 
     private void initGraphite(String graphiteServer, int graphitePort) {
@@ -130,19 +149,17 @@ public class FDBMetricsReporter {
                 convertDurationsTo(TimeUnit.MILLISECONDS).
                 filter(MetricFilter.ALL).
                 build(graphite);
-
     }
 
-    private void initSharded(String proxyHostname, int proxyPort) throws UnknownHostException {
-        this.sender = new WavefrontProxyClient.Builder(proxyHostname).metricsPort(proxyPort).build();
+    private WavefrontSender addWavefrontClient(WavefrontClientFactory wavefrontClientFactory, String client) {
+            wavefrontClientFactory.addClient(client,
+                    BATCH_SIZE,
+                    MAX_QUEUE_SIZE,
+                    FLUSH_INTERVAL_SECONDS,
+                    Integer.MAX_VALUE);
 
-        this.shardedReporter = new WavefrontInternalReporter.Builder().
-                withSource(getHostName()).
-                withReporterPointTag("service", SERVICE_NAME).
-                includeJvmMetrics().
-                build(this.sender);
+            return wavefrontClientFactory.getClient();
     }
-
 
     private String getHostName() {
         try {
@@ -154,11 +171,7 @@ public class FDBMetricsReporter {
     }
 
     void start() {
-        if (this.shardedReporter != null) {
-            this.shardedReporter.start(METRICS_REPORTING_PERIOD, TimeUnit.SECONDS);
-        } else {
-            this.reporter.start(METRICS_REPORTING_PERIOD, TimeUnit.SECONDS);
-        }
+        this.reporter.start(METRICS_REPORTING_PERIOD, TimeUnit.SECONDS);
         collectMetrics();
     }
 
@@ -221,7 +234,7 @@ public class FDBMetricsReporter {
                     return;
                 }
 
-                Tailer tailer = new Tailer(logFile, new FDBLogListener(prefix, values, gauges, shardedReporter), 1000, true);
+                Tailer tailer = new Tailer(logFile, new FDBLogListener(prefix, values, gauges, wavefrontSender), 1000, true);
                 es.submit(tailer);
                 if (files.putIfAbsent(logFile, tailer) != null) {
                     // The put didn't succeed, stop the tailer.

--- a/src/main/java/com/wavefront/integrations/FDBMetricsReporterArguments.java
+++ b/src/main/java/com/wavefront/integrations/FDBMetricsReporterArguments.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.Parameter;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class holds the configuration parameters for the fdb-metrics jar.
@@ -11,7 +12,7 @@ import java.util.List;
 public class FDBMetricsReporterArguments {
 
     enum ReporterType {
-        DIRECT, PROXY, GRAPHITE, SHARDED;
+        DIRECT, PROXY, GRAPHITE;
     }
 
     private static final String ALL_FILES = ".*";
@@ -19,6 +20,8 @@ public class FDBMetricsReporterArguments {
     private static final String DEFAULT_HOST = "localhost";
 
     private static final int DEFAULT_PORT = 2878;
+
+    private static final String DEFAULT_SERVICE_NAME = "fdbtailer";
 
     /**
      * @param reporterType The type of reporter that should be used to report the metrics gathered.  Current options are PROXY,
@@ -69,6 +72,14 @@ public class FDBMetricsReporterArguments {
     private String token;
 
     /**
+     * @param endPoints Array of URL endpoints to send metrics to. Only used if reporterType is set to DIRECT.
+     */
+    @Parameter(names = {"--endPoints"},
+            description = "List of endpoints if sending to multiple Wavefront instances. Accepts a comma separated" +
+                    "list in the form of `token@wavefronturl`. Only used if --type is set to DIRECT.")
+    private List<Map<String, String>> endPoints;
+
+    /**
      * @param graphiteServer The name of the machine running a Graphite server.  Only used if reporterType is set to
      *                       GRAPHITE.
      */
@@ -103,6 +114,14 @@ public class FDBMetricsReporterArguments {
             description = "A prefix to attach to all metrics collected.  The default is \"fdb.trace.\" if not specified.")
     private String prefix = "fdb.trace.";
 
+    /**
+     * @param serviceName An optional name for the service. Defaults to \"fdbtailer\" if not specified.
+     */
+    @Parameter(names = {"--serviceName", "-n"},
+            description = "Change the service name to another string. The default is \"fdbtailer\" if not specified.")
+    private String serviceName = DEFAULT_SERVICE_NAME;
+
+
     @Parameter(description = "")
     private List<String> unparsedParams;
 
@@ -130,6 +149,10 @@ public class FDBMetricsReporterArguments {
         this.token = token;
     }
 
+    public void setEndPoints(List<Map<String, String>> endPoints) {
+        this.endPoints = endPoints;
+    }
+
     public void setGraphiteServer(String graphiteServer) {
         this.graphiteServer = graphiteServer;
     }
@@ -140,6 +163,10 @@ public class FDBMetricsReporterArguments {
 
     public void setReporterType(ReporterType reporterType) {
         this.reporterType = reporterType;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
     }
 
     public String getDirectory() {
@@ -165,6 +192,8 @@ public class FDBMetricsReporterArguments {
     public String getToken() {
         return token;
     }
+
+    public List<Map<String, String>> getEndPoints() { return endPoints; }
 
     public String getGraphiteServer() {
         return graphiteServer;
@@ -205,4 +234,6 @@ public class FDBMetricsReporterArguments {
     public List<String> getUnparsedParams() {
         return unparsedParams;
     }
+
+    public String getServiceName() { return serviceName; }
 }

--- a/src/main/java/com/wavefront/integrations/FDBMetricsReporterInit.java
+++ b/src/main/java/com/wavefront/integrations/FDBMetricsReporterInit.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import org.apache.commons.lang3.ObjectUtils;
 
 import java.io.File;
 import java.net.UnknownHostException;
@@ -48,11 +47,10 @@ public class FDBMetricsReporterInit {
                 return false;
             }
         } else if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.DIRECT) {
-            if (arguments.getServer() == null || arguments.getToken() == null) {
+            if ((arguments.getServer() == null && arguments.getToken() == null) && arguments.getEndPoints() == null) {
                 return false;
             }
-        } else if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.PROXY ||
-                    arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.SHARDED) {
+        } else if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.PROXY) {
             if (arguments.getProxyHost() == null) {
                 return false;
             }

--- a/src/test/java/com/wavefront/integrations/FDBLogListenerTest.java
+++ b/src/test/java/com/wavefront/integrations/FDBLogListenerTest.java
@@ -33,6 +33,8 @@ public class FDBLogListenerTest {
         return prefix + name;
     }
 
+    private String serviceName = "fdbtailer";
+
     static {
         SharedMetricRegistries.setDefault("defaultFDBMetrics", new MetricRegistry());
     }
@@ -65,7 +67,7 @@ public class FDBLogListenerTest {
                 }
         );
 
-        listener = new FDBLogListener(prefix, values, gauges, null);
+        listener = new FDBLogListener(prefix, values, gauges, null, serviceName);
     }
 
     @Test

--- a/src/test/java/com/wavefront/integrations/FDBMetricsReporterInitTest.java
+++ b/src/test/java/com/wavefront/integrations/FDBMetricsReporterInitTest.java
@@ -4,8 +4,7 @@ import com.beust.jcommander.JCommander;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static com.wavefront.integrations.FDBMetricsReporterInit.isValid;
 import static com.wavefront.integrations.FDBMetricsReporterInit.parseArguments;
@@ -49,6 +48,10 @@ public class FDBMetricsReporterInitTest {
         String token = "abcde";
         int graphitePort = 3000;
         String graphiteServer = "graphite.example.com";
+        ArrayList endPoints = new ArrayList();
+        endPoints.add(new HashMap<String, String>(){{put("endPoint1", "token@endPoint1.wavefront.com");}});
+        endPoints.add(new HashMap<String, String>(){{put("endPoint2", "token@endPoint2.wavefront.com");}});
+        String serviceName = "loghead";
         FDBMetricsReporterArguments.ReporterType type = FDBMetricsReporterArguments.ReporterType.PROXY;
         String[] args = {"-f", "src/test/resources/test_config.yaml"};
         try {
@@ -63,6 +66,8 @@ public class FDBMetricsReporterInitTest {
         assertEquals(init.arguments.getServer(), server);
         assertEquals(init.arguments.getGraphitePort(), graphitePort);
         assertEquals(init.arguments.getGraphiteServer(), graphiteServer);
+        assertEquals(init.arguments.getEndPoints(), endPoints);
+        assertEquals(init.arguments.getServiceName(), serviceName);
         assertEquals(init.arguments.getReporterType(), type);
     }
 
@@ -77,7 +82,11 @@ public class FDBMetricsReporterInitTest {
         String dir = "/test/dir";
         String matching = "$a";
         FDBMetricsReporterArguments.ReporterType type = FDBMetricsReporterArguments.ReporterType.GRAPHITE;
-        String[] args = {"--type", "GRAPHITE", "--dir", "/test/dir", "--matching", "$a", "--server", "localhost", "--token", "abcdefg", "-f", "src/test/resources/test_config.yaml"};
+        String[] args = {"--type", "GRAPHITE", "--dir", "/test/dir", "--matching", "$a", "--server", "localhost",
+                "--token", "abcdefg",
+                "--serviceName", "loghead",
+                "--endPoints", "token@endPoint1.wavefront.com,token@endPoint2.wavefront.com",
+                "-f", "src/test/resources/test_config.yaml"};
         try {
             parseArguments(args, init);
 

--- a/src/test/resources/test_config.yaml
+++ b/src/test/resources/test_config.yaml
@@ -7,3 +7,7 @@ server: wavefront.example.com
 token: abcde
 graphiteServer: graphite.example.com
 graphitePort: 3000
+endPoints:
+  - endPoint1: "token@endPoint1.wavefront.com"
+  - endPoint2: "token@endPoint2.wavefront.com"
+serviceName: loghead


### PR DESCRIPTION
The requirement for this change is to allow `fdbtailer` to send metrics
to multiple endpoints. The changes include:
- Refactoring `FDBMetricsReporter.java` to use the `WavefrontClientFactory`
- Deprecating `wavefront-internal-reporter` in favour of the `wavefront-sdk-java`
- Removing the `SHARDED` reporter type and instead send the cluster file tagged by default
- Migrate to use `WavefrontSender` for multi-client support
- Allow setting of the service name. Defaults to `fdbtailer`
- Updated tests