### PR TITLE
Add feature to disable reporting of certain metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ The command line argument options are as follows:
      
 --type
      The type of reporter that should be used to report the metrics gathered.
-     Possible Values: [DIRECT, PROXY, GRAPHITE, SHARDED]
+     Possible Values: [DIRECT, PROXY, GRAPHITE]
+
+--disabledMetrics
+    Option to disable certain metrics collected by FDBTailer.
+    Possible Values: [role, machineMetrics, processMetrics, storageMetrics, masterCommit, rkUpdate, totalDataInFlight, movingData, machineLoadDetail, programStart, memSample, memSampleSummary]
 
 ```
 
@@ -105,6 +109,9 @@ matching: ".*\\.xml$"
 reporterType: PROXY
 proxyHost: 127.0.0.1
 proxyPort: 2878
+disabledMetrics:
+  - "machineLoadDetail"
+  - "memSampleSummary"
 ```
 
 This is a simple configuration that sets up the fdb-metrics application to send metrics to a Wavefront proxy running on the local machine.  It will examine all files ending with ```.xml``` in the directory ```/usr/local/foundationdb/logs```.

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -3,3 +3,14 @@ matching: ".*\\.xml$"
 reporterType: PROXY
 proxyHost: 127.0.0.1
 proxyPort: 2878
+server: wavefront.example.com
+token: abcde
+graphiteServer: graphite.example.com
+graphitePort: 3000
+endPoints:
+  - endPoint1: "token@endPoint1.wavefront.com"
+  - endPoint2: "token@endPoint2.wavefront.com"
+serviceName: loghead
+disableMetrics:
+  - "machineLoadDetail"
+  - "machineMetrics"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-fdb-tailer</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Wavefront Metrics Adaptor for FoundationDB Logs</name>
     <description>Reads FoundationDB trace logs and converts them to time-series metrics in Wavefront and

--- a/src/main/java/com/wavefront/integrations/FDBLogListener.java
+++ b/src/main/java/com/wavefront/integrations/FDBLogListener.java
@@ -68,14 +68,17 @@ public class FDBLogListener extends TailerListenerAdapter {
         return prefix + name;
     }
 
+    private List<String> disabledMetrics;
+
     public FDBLogListener(String prefix, LoadingCache<String, AtomicDouble> values,
-                          LoadingCache<String, Gauge<Double>> gauges, WavefrontSender wavefrontSender, String serviceName) {
+                          LoadingCache<String, Gauge<Double>> gauges, WavefrontSender wavefrontSender, String serviceName, List<String> disabledMetrics) {
         this.prefix = prefix;
         this.values = values;
         this.gauges = gauges;
         this.wavefrontSender = wavefrontSender;
         this.failed = SharedMetricRegistries.getDefault().counter(addPrefix("listener_failed"));
         this.tags = new HashMap<String, String>() {{put("service", serviceName);}};
+        this.disabledMetrics = disabledMetrics;
     }
 
     @Override
@@ -175,7 +178,7 @@ public class FDBLogListener extends TailerListenerAdapter {
                 Document doc = db.parse(new ByteArrayInputStream(line.getBytes(Charsets.UTF_8)));
                 NamedNodeMap map = doc.getDocumentElement().getAttributes();
                 Node type = map.getNamedItem("Type");
-                if (type != null) {
+                if (type != null && enableMetricReporting(type.getNodeValue())) {
                     switch (type.getNodeValue()) {
                         case "Role": {
                             // Track all transitions with booleans.  It isn't clear how often
@@ -333,6 +336,15 @@ public class FDBLogListener extends TailerListenerAdapter {
     private String getPort(NamedNodeMap map) {
         String machine = map.getNamedItem("Machine").getNodeValue();
         return machine.substring(machine.indexOf(":") + 1);
+    }
+
+    @VisibleForTesting
+    boolean enableMetricReporting(String nodeValue) {
+        boolean enabled = true;
+        if (disabledMetrics.toString().toLowerCase().contains(nodeValue.toLowerCase())) {
+            enabled = false;
+        }
+        return enabled;
     }
 
     @VisibleForTesting

--- a/src/main/java/com/wavefront/integrations/FDBLogListener.java
+++ b/src/main/java/com/wavefront/integrations/FDBLogListener.java
@@ -338,8 +338,7 @@ public class FDBLogListener extends TailerListenerAdapter {
         return machine.substring(machine.indexOf(":") + 1);
     }
 
-    @VisibleForTesting
-    boolean enableMetricReporting(String nodeValue) {
+    private boolean enableMetricReporting(String nodeValue) {
         boolean enabled = true;
         if (disabledMetrics.toString().toLowerCase().contains(nodeValue.toLowerCase())) {
             enabled = false;

--- a/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
+++ b/src/main/java/com/wavefront/integrations/FDBMetricsReporter.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
@@ -60,6 +61,8 @@ public class FDBMetricsReporter {
 
     private String SERVICE_NAME = "fdbtailer";
 
+    private List<String> disabledMetrics = new ArrayList<>();
+
     String metricName(String name) {
         return prefix + name;
     }
@@ -96,6 +99,10 @@ public class FDBMetricsReporter {
 
         if (arguments.getServiceName() != null) {
             SERVICE_NAME = arguments.getServiceName();
+        }
+
+        if (arguments.getDisabledMetrics() != null) {
+            disabledMetrics = arguments.getDisabledMetrics();
         }
 
         if (arguments.getReporterType() == FDBMetricsReporterArguments.ReporterType.PROXY) {
@@ -234,7 +241,7 @@ public class FDBMetricsReporter {
                     return;
                 }
 
-                Tailer tailer = new Tailer(logFile, new FDBLogListener(prefix, values, gauges, wavefrontSender, SERVICE_NAME), 1000, true);
+                Tailer tailer = new Tailer(logFile, new FDBLogListener(prefix, values, gauges, wavefrontSender, SERVICE_NAME, disabledMetrics), 1000, true);
                 es.submit(tailer);
                 if (files.putIfAbsent(logFile, tailer) != null) {
                     // The put didn't succeed, stop the tailer.

--- a/src/main/java/com/wavefront/integrations/FDBMetricsReporterArguments.java
+++ b/src/main/java/com/wavefront/integrations/FDBMetricsReporterArguments.java
@@ -121,6 +121,13 @@ public class FDBMetricsReporterArguments {
             description = "Change the service name to another string. The default is \"fdbtailer\" if not specified.")
     private String serviceName = DEFAULT_SERVICE_NAME;
 
+    /**
+     * @param disableMetrics Disables metric types provided. Possible values: role, machineMetrics, processMetrics,
+     *                       storageMetrics, masterCommit, rkUpdate, totalDataInFlight, movingData, machineLoadDetails,
+     *                       programStart, memSample, memSampleSummary
+     */
+    private List<String> disabledMetrics;
+
 
     @Parameter(description = "")
     private List<String> unparsedParams;
@@ -168,6 +175,8 @@ public class FDBMetricsReporterArguments {
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
     }
+
+    public void setDisabledMetrics(List<String> disabledMetrics) { this.disabledMetrics = disabledMetrics; }
 
     public String getDirectory() {
         return directory;
@@ -236,4 +245,6 @@ public class FDBMetricsReporterArguments {
     }
 
     public String getServiceName() { return serviceName; }
+
+    public List<String> getDisabledMetrics() { return disabledMetrics; }
 }

--- a/src/test/java/com/wavefront/integrations/FDBLogListenerTest.java
+++ b/src/test/java/com/wavefront/integrations/FDBLogListenerTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -34,6 +36,8 @@ public class FDBLogListenerTest {
     }
 
     private String serviceName = "fdbtailer";
+
+    private List<String> disabledMetrics = Arrays.asList("machineMetrics");
 
     static {
         SharedMetricRegistries.setDefault("defaultFDBMetrics", new MetricRegistry());
@@ -67,7 +71,7 @@ public class FDBLogListenerTest {
                 }
         );
 
-        listener = new FDBLogListener(prefix, values, gauges, null, serviceName);
+        listener = new FDBLogListener(prefix, values, gauges, null, serviceName, disabledMetrics);
     }
 
     @Test

--- a/src/test/java/com/wavefront/integrations/FDBMetricsReporterInitTest.java
+++ b/src/test/java/com/wavefront/integrations/FDBMetricsReporterInitTest.java
@@ -52,6 +52,7 @@ public class FDBMetricsReporterInitTest {
         endPoints.add(new HashMap<String, String>(){{put("endPoint1", "token@endPoint1.wavefront.com");}});
         endPoints.add(new HashMap<String, String>(){{put("endPoint2", "token@endPoint2.wavefront.com");}});
         String serviceName = "loghead";
+        List<String> disabledMetrics = Arrays.asList("machineMetrics", "machineLoadDetails");
         FDBMetricsReporterArguments.ReporterType type = FDBMetricsReporterArguments.ReporterType.PROXY;
         String[] args = {"-f", "src/test/resources/test_config.yaml"};
         try {
@@ -69,6 +70,7 @@ public class FDBMetricsReporterInitTest {
         assertEquals(init.arguments.getEndPoints(), endPoints);
         assertEquals(init.arguments.getServiceName(), serviceName);
         assertEquals(init.arguments.getReporterType(), type);
+        assertEquals(init.arguments.getDisabledMetrics(), disabledMetrics);
     }
 
     @Test

--- a/src/test/resources/test_config.yaml
+++ b/src/test/resources/test_config.yaml
@@ -11,3 +11,6 @@ endPoints:
   - endPoint1: "token@endPoint1.wavefront.com"
   - endPoint2: "token@endPoint2.wavefront.com"
 serviceName: loghead
+disabledMetrics:
+  - "machineMetrics"
+  - "machineLoadDetails"


### PR DESCRIPTION
Some loglines in FoundationDB generate a large number of metrics. Some of
these metrics (such as MachineMetrics and MachineLoadDetail) can be generated from
other sources. This change lets a user disable metrics from reporting.

Adding the following in the FDBTailer YAML configuration file will disable
reporting for MachineMetrics and MachineLoadDetail:

```
disabledMetrics:
  - "machineMetrics"
  - "machineLoadDetail"
```

By default all metrics are being reported.