### PR TITLE
MONIT-30953 - CVE-2020-15250 (5.5) - wavefront-fdb-tailer (junit)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-            <version>4.12</version>
+            <version>4.13.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Updated junit from 4.12 to 4.13.2
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/105360657/196697369-d1b82455-9343-4a59-a7dc-379cd8ab058d.png">
