### PR TITLE
Update disableMetrics field name

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -11,6 +11,6 @@ endPoints:
   - endPoint1: "token@endPoint1.wavefront.com"
   - endPoint2: "token@endPoint2.wavefront.com"
 serviceName: loghead
-disableMetrics:
+disabledMetrics:
   - "machineLoadDetail"
   - "machineMetrics"


### PR DESCRIPTION
Looks like code expects the field `disabledMetrics` instead of `disableMetrics`. I was trying to run wavefront-fdb-tailer using example_config.yaml and it was throwing an error as shown below,

SEVERE: Failed to parse yaml config file: ../example_config.yaml com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "disableMetrics" (class com.wavefront.integrations.FDBMetricsReporterArguments), not marked as ignorable (16 known properties: "serviceName", "help", "server", "disabledMetrics", "directory", "proxyPort", "unparsedParams", "prefix", "proxyHost", "token", "reporterType", "matching", "endPoints", "graphitePort", "graphiteServer", "configFile"])
 at [Source: (File); line: 15, column: 3] (through reference chain: com.wavefront.integrations.FDBMetricsReporterArguments["disableMetrics"])